### PR TITLE
Added Turkish Lira symbol

### DIFF
--- a/src/components/iso4217.service.js
+++ b/src/components/iso4217.service.js
@@ -780,7 +780,7 @@ angular.module('isoCurrency.common', [])
 			'TRY': {
 				text: 'Turkish Lira',
 				fraction: 2,
-				symbol: ''
+				symbol: '₺'
 			},
 			'TMT': {
 				text: 'Turkmenistan New Manat',


### PR DESCRIPTION
Since 2012 Turkish Lira is in unicode http://en.wikipedia.org/wiki/Turkish_lira_sign
