### PR TITLE
Added param type and return only symbol

### DIFF
--- a/src/components/isoCurrency.filter.js
+++ b/src/components/isoCurrency.filter.js
@@ -9,18 +9,29 @@ angular.module('isoCurrency', ['isoCurrency.common'])
 		/**
 		 * transforms an amount into the right format and currency according to a passed currency code (3 chars).
 		 *
-		 * @param float amount
+		 * @param float amount, if undefined return only currency symbol or name
 		 * @param string currencyCode e.g. EUR, USD
 		 * @param number fraction User specified fraction size that overwrites default value
+		 * @param string type of result you want, "text" to return currency name anything else to return the symbol
 		 * @return string
 		 */
-		return function(amount, currencyCode, fraction) {
+		return function(amount, currencyCode, fraction, type) {
 			if (!currencyCode) {
 				return;
 			}
 			var currency = iso4217.getCurrencyByCode(currencyCode);
 			var fractionSize = (fraction === void 0) ? currency.fraction : fraction;
-			return $filter('currency')(amount, currency.symbol, fractionSize);
+			var out = (type === 'text') ? currency.text : currency.symbol;
+
+			if (currency.symbol) {
+				if (amount !== undefined) {
+					return $filter('currency')(amount, out, fractionSize);
+				} else {
+					return out;
+				}
+			} else {
+				return $filter('currency')(amount, currencyCode, fractionSize);
+			}
 		};
 
 	}]);


### PR DESCRIPTION
I added a param "type" to ask to return the currency full name (text) or the currency symbol (symbol).
Then I added a couple of conditions, first of all, if currency symbol doesn't exist return the currency code, then there is possibility you need only to convert the 3 letter ISO code to the right symbol without any amount, so I added the condition if you pass an undefined "amount" it returns only the currency related symbol, so now you can use the filter to simply convert 3 letter ISO codes to symbols.
Hope you can pull it in master branch.
Thanks

EDIT:
New usage could be:

```
// in controller
$scope.amount = 50.50;
$scope.currency = 'USD';
$scope.type = 'text';

// in template
{{ amount | isoCurrency:currency }} // $50.50
{{ amount | isoCurrency:currency:0 }} // $50
{{ amount | isoCurrency:currency:0:type }} // Dollar 50
{{ undefined | isoCurrency:currency:0:type }} // Dollar
{{ undefined | isoCurrency:currency }} // $
```
