### PR TITLE
fix: Add "main" entry for CommonJS / Browserify support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Simon Wicki <sim.wicki@gmail.com>",
   "repository": "git@github.com:zwacky/isoCurrency.git",
   "license": "MIT",
+  "main": "dist/isoCurrency.js",
   "devDependencies": {
     "angular": "^1.4.6",
     "angular-mocks": "^1.4.6",


### PR DESCRIPTION
In order to `require` the node module, the `package.json` needs a `main` property.
