### PR TITLE
ZAR is officially referred to as the South African Rand

### DIFF
--- a/src/components/iso4217.service.js
+++ b/src/components/iso4217.service.js
@@ -456,7 +456,7 @@ angular.module('isoCurrency.common', [])
 				symbol: false
 			},
 			'ZAR': {
-				text: 'Rand',
+				text: 'South African Rand',
 				fraction: 2,
 				symbol: 'R'
 			},


### PR DESCRIPTION
See https://en.wikipedia.org/wiki/ISO_4217
