### PR TITLE
Update the peru currency symbol 

### DIFF
--- a/src/components/iso4217.service.js
+++ b/src/components/iso4217.service.js
@@ -608,7 +608,7 @@ angular.module('isoCurrency.common', [])
 			'PEN': {
 				text: 'Nuevo Sol',
 				fraction: 2,
-				symbol: 'S/.'
+				symbol: 'S/'
 			},
 			'PHP': {
 				text: 'Philippine Peso',


### PR DESCRIPTION
Update the peru currency symbol from `S/.` to `S/` as defined in the wikipedia: https://en.wikipedia.org/wiki/Peruvian_nuevo_sol
